### PR TITLE
More Popup Adjustments: Left Old infoTemplate Formatting as comments

### DIFF
--- a/search.js
+++ b/search.js
@@ -2,17 +2,109 @@ require([
   "esri/map",
   "esri/dijit/Search",
   "esri/layers/FeatureLayer",
+  "esri/dijit/Popup", "esri/dijit/PopupTemplate",
+  "esri/symbols/SimpleFillSymbol", "esri/Color",
+  "dojo/dom-class", "dojo/dom-construct", "dojo/on",
+  // "dojox/charting/Chart", "dojox/charting/themes/Dollar",
   "esri/InfoTemplate",
   "dojo/domReady!"
   ],
 
-// ----------------------Create Map with basemap-----------------------
-  function (Map, Search, FeatureLayer, InfoTemplate) {
+
+//------------------------------------------------------------------
+// ----------------------Initialize Functions-----------------------
+//------------------------------------------------------------------
+  function (
+    Map,
+    Search,
+    FeatureLayer,
+    Popup, PopupTemplate,
+    SimpleFillSymbol, Color,
+    domClass, domConstruct, on,
+    InfoTemplate
+  ) {
+
+// --------------------Popup Shell Setup-----------------------------------
+    var fill = new SimpleFillSymbol("solid", null, new Color("#A4CE67"));
+    var popup = new Popup({
+      fillSymbol: fill,
+      titleInBody: false
+    }, domConstruct.create("div"));
+
+    //Add Popup theme
+    domClass.add(popup.domNode, "dark");
+
+
+
+
+//--------------------Create Map-----------------------------------------
     var map = new Map("map", {
       basemap: "dark-gray",
       center: [-72.68, 43.785], // lon, lat
-      zoom:8
+      zoom:8,
+      infoWindow: popup
     });
+
+
+// -----------------Define PopupTemplates------------------------------
+    //Crossing Template
+    var crossingTemplate = new PopupTemplate({
+      title: "Summary Info for Crossing {DOT_Num}",
+
+      fieldInfos: [
+        { fieldName: "DOT_Num", visible: true, format: { places: 0} },
+        { fieldName: "LineName", visible: true, format: { places: 0} },
+        { fieldName: "Feature_Crossed", visible: true, format: { places: 0} },
+        { fieldName: "WDCode", visible: true, format: { places: 0} },
+        { fieldName: "SurfaceType", visible: true, format: { places: 0} },
+        { fieldName: "XingCond", visible: true, format: { places: 0} },
+      ],
+
+      showAttachments: true,
+    });
+
+    //Sign Template
+    var signTemplate = new PopupTemplate({
+      title: "Summary Info for Crossing Sign",
+
+      fieldInfos: [
+        { fieldName: "DOT_Num", visible: true, format: { places: 0} },
+        { fieldName: "SignType", visible: true, format: { places: 0} },
+        { fieldName: "Post", visible: true, format: { places: 0} },
+        { fieldName: "Reflective", visible: true, format: { places: 0} },
+        { fieldName: "ReflSheetCond", visible: true, format: { places: 0} },
+        { fieldName: "InstallDate", visible: true, format: { places: 0} },
+        { fieldName: "SignCondition", visible: true, format: { places: 0} },
+      ],
+
+      showAttachments: true,
+    });
+
+    //Rail Line Template
+    var lineTemplate = new PopupTemplate({
+      title: "Summary Info for Rail Line",
+
+      fieldInfos: [
+        { fieldName: "LineName", visible: true, format: { places: 0} },
+        { fieldName: "Division", visible: true, format: { places: 0} },
+        { fieldName: "Subdivision", visible: true, format: { places: 0} },
+        { fieldName: "Branch", visible: true, format: { places: 0} },
+      ],
+    });
+
+    //AADT Template
+    var aadtTemplate = new PopupTemplate({
+      title: "Average Annual Daily Traffic at Station {ATRStation}",
+
+      fieldInfos: [
+        { fieldName: "aadt", label: "AADT", visible: true, format: { places: 0} },
+        { fieldName: "ATRStation", label: "Automated Traffic Recording Station", visible: true, format: { places: 0} },
+        { fieldName: "YEAR", label: "Last Year Counted", visible: true, format: { places: 0} },
+        { fieldName: "RouteName", label: "Route Name", visible: true, format: { places: 0} },
+        { fieldName: "RouteNum", label: "Route Number", visible: true, format: { places: 0} },
+      ],
+    });
+
 
 
 
@@ -20,7 +112,7 @@ require([
     //Create Crossing Feature Layer
     var crossingUrl = "http://services1.arcgis.com/NXmBVyW5TaiCXqFs/arcgis/rest/services/CrossingInspections2015/FeatureServer/1";
 
-    var crossingTemplate = new InfoTemplate("Railroad Crossing", "DOT Crossing Number: ${DOT_Num}</br>Line Name: ${LineName}</br>Feature Crossed: ${Feature_Crossed}</br>Warning Device Level: ${WDCode}</br>Crossing Codition: ${XingCond}");
+    // var crossingTemplate = new InfoTemplate("Railroad Crossing", "DOT Crossing Number: ${DOT_Num}</br>Line Name: ${LineName}</br>Feature Crossed: ${Feature_Crossed}</br>Warning Device Level: ${WDCode}</br>Crossing Codition: ${XingCond}");
 
     var crossingPoints = new FeatureLayer(crossingUrl, {
       id: "crossing-points",
@@ -33,7 +125,7 @@ require([
     //Create Sign Feature Layer
     var signUrl = "http://services1.arcgis.com/NXmBVyW5TaiCXqFs/arcgis/rest/services/CrossingInspections2015/FeatureServer/0";
 
-    var signTemplate = new InfoTemplate("Crossing Sign", "DOT Crossing Number: ${DOT_Num}</br>Sign Type: ${SignType}</br>Sign Condition: ${SignCondition}</br>Installation Date: ${InstallDate}");
+    // var signTemplate = new InfoTemplate("Crossing Sign", "DOT Crossing Number: ${DOT_Num}</br>Sign Type: ${SignType}</br>Sign Condition: ${SignCondition}</br>Installation Date: ${InstallDate}");
 
     var signPoints = new FeatureLayer(signUrl, {
       id: "sign-points",
@@ -46,7 +138,7 @@ require([
     //Create Rail Line Feature Layer
     var lineUrl = "http://vtransmap01.aot.state.vt.us/arcgis/rest/services/Rail/Rail_Lines/MapServer/0";
 
-    var lineTemplate = new InfoTemplate("Railroad Line", "Line Name: ${LineName}</br>Division: ${Division}</br>Subdivision: ${Subdivision}</br>Branch: ${Branch}");
+    // var lineTemplate = new InfoTemplate("Railroad Line", "Line Name: ${LineName}</br>Division: ${Division}</br>Subdivision: ${Subdivision}</br>Branch: ${Branch}");
 
     var railLine = new FeatureLayer(lineUrl, {
       id: "rail-line",
@@ -58,7 +150,7 @@ require([
     //Create AADT Line Feature Layer
     var aadtUrl = "https://services1.arcgis.com/NXmBVyW5TaiCXqFs/ArcGIS/rest/services/AADT_2013_StateHighways/FeatureServer/0";
 
-    var aadtTemplate = new InfoTemplate("Average Annual Daily Traffic", "AADT Count: ${aadt}</br>Year: ${YEAR}</br>Station ID: ${ATRStation}");
+    // var aadtTemplate = new InfoTemplate("Average Annual Daily Traffic", "AADT Count: ${aadt}</br>Year: ${YEAR}</br>Station ID: ${ATRStation}");
 
     var aadtLine = new FeatureLayer(aadtUrl, {
       id: "aadt-line",
@@ -80,6 +172,7 @@ require([
       enableLabel: false,
       enableInfoWindow: true,
       showInfoWindowOnSelect: true,
+      infoWindow: popup,
       enableHighlight: false,
       allPlaceholder: "Search for Railroad Crossings, Signs, Addresses or Places",
       map: map,
@@ -94,7 +187,7 @@ require([
       searchFields: ["DOT_Num", "RRXingNum", "Town", "County", "LineName", "Feature_Crossed"],
       suggestionTemplate: "${DOT_Num}, Line: ${LineName}, Street: ${Feature_Crossed}, Warning Device: ${WDCode}, Condition: ${XingCond}",
       exactMatch: false,
-      outFields: ["DOT_Num", "Feature_Crossed", "LineName", "WDCode", "XingCond"],
+      outFields: ["*"],
       name: "Railroad Crossings",
       placeholder: "Search by DOT #, Line, Street, Town, or County",
       maxResults: 15,
@@ -102,7 +195,8 @@ require([
 
 
       //Create an InfoTemplate and include three fields
-      infoTemplate: new InfoTemplate("Railroad Crossing", "DOT Crossing Number: ${DOT_Num}</br>Line Name: ${LineName}</br>Feature Crossed: ${Feature_Crossed}</br>Warning Device Level: ${WDCode}</br>Crossing Codition: ${XingCond}"),
+      infoTemplate: crossingTemplate,
+      // new InfoTemplate("Railroad Crossing", "DOT Crossing Number: ${DOT_Num}</br>Line Name: ${LineName}</br>Feature Crossed: ${Feature_Crossed}</br>Warning Device Level: ${WDCode}</br>Crossing Codition: ${XingCond}"),
       enableSuggestions: true,
       minCharacters: 0
     });
@@ -122,7 +216,8 @@ require([
       maxSuggestions: 15,
 
       //Create an InfoTemplate
-      infoTemplate: new InfoTemplate("Crossing Sign Information", "DOT # of Associated Crossing: ${DOT_Num}</br>Type of Sign: ${SignType}</br>Condition: ${SignCondition}"),
+      infoTemplate: signTemplate,
+      // new InfoTemplate("Crossing Sign Information", "DOT # of Associated Crossing: ${DOT_Num}</br>Type of Sign: ${SignType}</br>Condition: ${SignCondition}"),
 
       enableSuggestions: true,
       minCharacters: 0

--- a/search.js
+++ b/search.js
@@ -52,12 +52,12 @@ require([
       title: "Summary Info for Crossing {DOT_Num}",
 
       fieldInfos: [
-        { fieldName: "DOT_Num", visible: true, format: { places: 0} },
-        { fieldName: "LineName", visible: true, format: { places: 0} },
-        { fieldName: "Feature_Crossed", visible: true, format: { places: 0} },
-        { fieldName: "WDCode", visible: true, format: { places: 0} },
-        { fieldName: "SurfaceType", visible: true, format: { places: 0} },
-        { fieldName: "XingCond", visible: true, format: { places: 0} },
+        { fieldName: "DOT_Num", label: "DOT Crossing Number", visible: true, format: { places: 0} },
+        { fieldName: "LineName", label: "Rail Line", visible: true, format: { places: 0} },
+        { fieldName: "Feature_Crossed", label: "Feature Crossed", visible: true, format: { places: 0} },
+        { fieldName: "WDCode", label: "Warning Device Level", visible: true, format: { places: 0} },
+        { fieldName: "SurfaceType", label: "Primary Crossing Surface Material", visible: true, format: { places: 0} },
+        { fieldName: "XingCond", label: "Overall Condition", visible: true, format: { places: 0} },
       ],
 
       showAttachments: true,
@@ -68,13 +68,13 @@ require([
       title: "Summary Info for Crossing Sign",
 
       fieldInfos: [
-        { fieldName: "DOT_Num", visible: true, format: { places: 0} },
-        { fieldName: "SignType", visible: true, format: { places: 0} },
-        { fieldName: "Post", visible: true, format: { places: 0} },
-        { fieldName: "Reflective", visible: true, format: { places: 0} },
-        { fieldName: "ReflSheetCond", visible: true, format: { places: 0} },
-        { fieldName: "InstallDate", visible: true, format: { places: 0} },
-        { fieldName: "SignCondition", visible: true, format: { places: 0} },
+        { fieldName: "DOT_Num", label: "DOT Crossing Number", visible: true, format: { places: 0} },
+        { fieldName: "SignType", label: "Type of Sign", visible: true, format: { places: 0} },
+        { fieldName: "Post", label: "Type of Sign Post", visible: true, format: { places: 0} },
+        { fieldName: "Reflective", label: "ASTM Reflective Sheeting", visible: true, format: { places: 0} },
+        { fieldName: "ReflSheetCond", label: "Reflective Sheeting Condition", visible: true, format: { places: 0} },
+        { fieldName: "InstallDate", label: "Installation Date", visible: true, format: { places: 0} },
+        { fieldName: "SignCondition", label: "Overall Condition", visible: true, format: { places: 0} },
       ],
 
       showAttachments: true,
@@ -85,7 +85,7 @@ require([
       title: "Summary Info for Rail Line",
 
       fieldInfos: [
-        { fieldName: "LineName", visible: true, format: { places: 0} },
+        { fieldName: "LineName", label: "Rail Line", visible: true, format: { places: 0} },
         { fieldName: "Division", visible: true, format: { places: 0} },
         { fieldName: "Subdivision", visible: true, format: { places: 0} },
         { fieldName: "Branch", visible: true, format: { places: 0} },
@@ -172,7 +172,6 @@ require([
       enableLabel: false,
       enableInfoWindow: true,
       showInfoWindowOnSelect: true,
-      infoWindow: popup,
       enableHighlight: false,
       allPlaceholder: "Search for Railroad Crossings, Signs, Addresses or Places",
       map: map,


### PR DESCRIPTION
Missing photo attachments on popup created when a search is run. Photo attachments show up at links in popups when you click a crossing or sign feature. I want to change this so that they show up as scrollable thumbnails in popup and have it show up on a search. 
